### PR TITLE
Change builder for font. Only woff include in css (base 64)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 lib
 node_modules
+.history

--- a/webpack-config-builder.js
+++ b/webpack-config-builder.js
@@ -171,7 +171,21 @@ const defaultConfig = definedVariables => ({
                 query: { mimetype: 'image/gif' }
             },
             {
-                test: /\.(woff|woff2|ttf|eot|svg)(\?.*)?$/,
+                test: /\.ttf(\?.*)?$/,
+                loader: 'url-loader',
+                query: { limit: 50000, mimetype: 'application/octet-stream' }
+            },
+            {
+                test: /\.eot(\?.*)?$/,
+                loader: 'file'
+            },
+            {
+                test: /\.woff2(\?.*)?$/,
+                loader: 'url-loader',
+                query: { limit: 50000, mimetype: 'application/font-woff' }
+            },
+            {
+                test: /\.woff(\?.*)?$/,
                 loader: require.resolve('base64-font-loader')
             },
             {


### PR DESCRIPTION
The config builder include only woff in css (is unterstood by all browsers). The other font file types are keeped beside for compatibility. 