### PR TITLE
Fix the BABELIFIED_PATH

### DIFF
--- a/webpack-config-builder.js
+++ b/webpack-config-builder.js
@@ -35,9 +35,9 @@ MINIMIFY = JSON.parse(MINIMIFY);
 SOURCE_MAPS = JSON.parse(SOURCE_MAPS);
 DEBUG = JSON.parse(DEBUG);
 OUTPUT_PUBLIC_PATH = OUTPUT_PUBLIC_PATH !== undefined ? OUTPUT_PUBLIC_PATH : `http://${DEV_SERVER_HOST}:${DEV_SERVER_PORT}/`;
-BABELIFIED_PATH = [].concat(BABELIFIED_PATH);
+BABELIFIED_PATH = BABELIFIED_PATH.split("/");
 const babelifiedIncludes = BABELIFIED_PATH.map((relativePath) => {
-    return path.resolve(process.cwd(), relativePath);
+    return path.resolve(process.cwd(), relativePath.trim());
 });
 /*************************************
 ********* Webpack config *************


### PR DESCRIPTION
The BABELIFIED_PATH must be a string. So to give multiple path to babelified, you'll siply give a string with all your pathes seperated by a comma.

cf https://github.com/KleeGroup/webpack-focus/commit/5ff3bf31d334f8b1f40c3b7d66c31c23401da12c#diff-11e9f7f953edc64ba14b0cc350ae7b9d from master branch.