### PR TITLE
Adding CORS by default

### DIFF
--- a/src/dev-server.js
+++ b/src/dev-server.js
@@ -43,6 +43,9 @@ const defaultServerConfig = {
     // By default, proxy all request different from built files, to the API
     proxy: {
         // '**': API_ROOT
+    },
+    headers: {
+        "Access-Control-Allow-Origin": "*"
     }
 };
 


### PR DESCRIPTION
Font are not loaded, because of CORS problems.
It was there in webpack 1